### PR TITLE
cicd: 自動デプロイ設定の追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ on:
     paths:
       - 'tf/**'
 
+# AWSとOIDC連携するには必要な設定らしい
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   terraform-plan:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,30 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
           # stateの取得に必要なポリシーを一時的に付与する
-          managed-session-policies: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+          inline-session-policy: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}"
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject"
+                  ],
+                  "Resource": [
+                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}/*"
+                  ]
+                }
+              ]
+            }
 
       - name: Write Terraform variables file
         working-directory: tf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,21 +37,24 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
+        working-directory: tf
         # secretsに改行を含む場合はbase64エンコードしておく必要があるっぽい
         # https://zenn.dev/coedo/scraps/d6e1efdf5311c7
         run: echo -n ${{ secrets.TERRAFORM_VARS }} | base64 --decode > terraform.tfvars
 
       - name: Initialize Terraform
+        working-directory: tf
         run: terraform init
 
       - name: Run Terraform Plan
+        working-directory: tf
         run: terraform plan -var-file=terraform.tfvars -out=tfplan
 
       - name: Upload Terraform Plan as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: terraform-plan
-          path: tfplan
+          path: tf/tfplan
 
   terraform-apply:
     if: github.event_name == 'push'
@@ -72,12 +75,15 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
+        working-directory: tf
         # secretsに改行を含む場合はbase64エンコードしておく必要があるっぽい
         # https://zenn.dev/coedo/scraps/d6e1efdf5311c7
         run: echo -n ${{ secrets.TERRAFORM_VARS }} | base64 --decode > terraform.tfvars
 
       - name: Initialize Terraform
+        working-directory: tf
         run: terraform init
 
       - name: Apply Terraform Plan
+        working-directory: tf
         run: terraform apply -var-file=terraform.tfvars -auto-approve

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,52 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
+          # デプロイに必要なポリシーを一時的に付与する
+          inline-session-policy: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:ListBucket",
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "iam:CreateRole",
+                    "iam:DeleteRole",
+                    "iam:UpdateRole",
+                    "iam:AttachRolePolicy",
+                    "iam:DetachRolePolicy",
+                    "iam:PassRole",
+                    "iam:CreatePolicy",
+                    "iam:DeletePolicy",
+                    "iam:UpdatePolicy",
+                    "lambda:CreateFunction",
+                    "lambda:DeleteFunction",
+                    "lambda:UpdateFunctionCode",
+                    "lambda:UpdateFunctionConfiguration",
+                    "lambda:AddPermission",
+                    "lambda:RemovePermission",
+                    "logs:CreateLogGroup",
+                    "logs:DeleteLogGroup",
+                    "logs:PutRetentionPolicy",
+                    "events:PutRule",
+                    "events:DeleteRule",
+                    "events:PutTargets",
+                    "events:RemoveTargets",
+                    "resource-groups:CreateGroup",
+                    "resource-groups:DeleteGroup",
+                    "resource-groups:Tag",
+                    "resource-groups:Untag",
+                    "resource-groups:UpdateGroupQuery"
+                  ],
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            }
 
       - name: Write Terraform variables file
         working-directory: tf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
                     "s3:GetObject"
                   ],
                   "Resource": [
-                    "arn:aws:s3:::${{ secrets.S3_BUCKET_FOR_STATE }}/*"
+                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}/*"
                   ]
                 }
               ]
@@ -60,7 +60,7 @@ jobs:
 
       - name: Initialize Terraform
         working-directory: tf
-        run: terraform init -backend-config="bucket=${{ secrets.S3_BUCKET_FOR_STATE }}" -backend-config="key=anime-schedules/terraform.tfstate" -backend-config="region=ap-northeast-1"
+        run: terraform init -backend-config="bucket=${{ vars.S3_BUCKET_FOR_STATE }}" -backend-config="key=anime-schedules/terraform.tfstate" -backend-config="region=ap-northeast-1"
 
       - name: Run Terraform Plan
         working-directory: tf
@@ -144,7 +144,7 @@ jobs:
 
       - name: Initialize Terraform
         working-directory: tf
-        run: terraform init -backend-config="bucket=${{ secrets.S3_BUCKET_FOR_STATE }}" -backend-config="key=anime-schedules/terraform.tfstate" -backend-config="region=ap-northeast-1"
+        run: terraform init -backend-config="bucket=${{ vars.S3_BUCKET_FOR_STATE }}" -backend-config="key=anime-schedules/terraform.tfstate" -backend-config="region=ap-northeast-1"
 
       - name: Apply Terraform Plan
         working-directory: tf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
-          # stateの取得に必要なポリシーを一時的に付与する
+          # stateの取得に必要なポリシーに制限する
           inline-session-policy: |
             {
               "Version": "2012-10-17",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,19 +43,12 @@ jobs:
                 {
                   "Effect": "Allow",
                   "Action": [
+                    "s3:GetObject",
                     "s3:ListBucket"
                   ],
                   "Resource": [
+                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}/*",
                     "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}"
-                  ]
-                },
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:GetObject"
-                  ],
-                  "Resource": [
-                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}/*"
                   ]
                 }
               ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,9 @@ jobs:
           terraform_version: 1.5.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
@@ -60,11 +59,10 @@ jobs:
           terraform_version: 1.5.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
         run: echo "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
-        run: echo "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
+        run: echo -e "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
 
       - name: Initialize Terraform
         run: terraform init
@@ -70,7 +70,7 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
-        run: echo "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
+        run: echo -e "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
 
       - name: Initialize Terraform
         run: terraform init

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,22 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
+          # stateの取得に必要なポリシーを一時的に付与する
+          inline-session-policy: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                  ],
+                  "Resource": [
+                    "arn:aws:s3:::${{ secrets.S3_BUCKET_FOR_STATE }}/*"
+                  ]
+                }
+              ]
+            }
 
       - name: Write Terraform variables file
         working-directory: tf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
                 {
                   "Effect": "Allow",
                   "Action": [
-                    "s3:GetObject",
+                    "s3:GetObject"
                   ],
                   "Resource": [
                     "arn:aws:s3:::${{ secrets.S3_BUCKET_FOR_STATE }}/*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,9 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
-        run: echo -e "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
+        # secretsに改行を含む場合はbase64エンコードしておく必要があるっぽい
+        # https://zenn.dev/coedo/scraps/d6e1efdf5311c7
+        run: echo -n ${{ secrets.TERRAFORM_VARS }} | base64 --decode > terraform.tfvars
 
       - name: Initialize Terraform
         run: terraform init
@@ -70,7 +72,9 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Write Terraform variables file
-        run: echo -e "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
+        # secretsに改行を含む場合はbase64エンコードしておく必要があるっぽい
+        # https://zenn.dev/coedo/scraps/d6e1efdf5311c7
+        run: echo -n ${{ secrets.TERRAFORM_VARS }} | base64 --decode > terraform.tfvars
 
       - name: Initialize Terraform
         run: terraform init

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Terraform Deployment
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    paths:
+      - 'tf/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'tf/**'
+
+jobs:
+  terraform-plan:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - name: Write Terraform variables file
+        run: echo "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
+
+      - name: Initialize Terraform
+        run: terraform init
+
+      - name: Run Terraform Plan
+        run: terraform plan -var-file=terraform.tfvars -out=tfplan
+
+      - name: Upload Terraform Plan as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: terraform-plan
+          path: tfplan
+
+  terraform-apply:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Write Terraform variables file
+        run: echo "${{ secrets.TERRAFORM_VARS }}" > terraform.tfvars
+
+      - name: Initialize Terraform
+        run: terraform init
+
+      - name: Apply Terraform Plan
+        run: terraform apply -var-file=terraform.tfvars -auto-approve

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,30 +36,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
           # stateの取得に必要なポリシーを一時的に付与する
-          inline-session-policy: |
-            {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:ListBucket"
-                  ],
-                  "Resource": [
-                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}"
-                  ]
-                },
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:GetObject"
-                  ],
-                  "Resource": [
-                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}/*"
-                  ]
-                }
-              ]
-            }
+          managed-session-policies: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
 
       - name: Write Terraform variables file
         working-directory: tf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,52 +91,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
-          # デプロイに必要なポリシーを一時的に付与する
-          inline-session-policy: |
-            {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:ListBucket",
-                    "s3:GetObject",
-                    "s3:PutObject",
-                    "s3:DeleteObject",
-                    "iam:CreateRole",
-                    "iam:DeleteRole",
-                    "iam:UpdateRole",
-                    "iam:AttachRolePolicy",
-                    "iam:DetachRolePolicy",
-                    "iam:PassRole",
-                    "iam:CreatePolicy",
-                    "iam:DeletePolicy",
-                    "iam:UpdatePolicy",
-                    "lambda:CreateFunction",
-                    "lambda:DeleteFunction",
-                    "lambda:UpdateFunctionCode",
-                    "lambda:UpdateFunctionConfiguration",
-                    "lambda:AddPermission",
-                    "lambda:RemovePermission",
-                    "logs:CreateLogGroup",
-                    "logs:DeleteLogGroup",
-                    "logs:PutRetentionPolicy",
-                    "events:PutRule",
-                    "events:DeleteRule",
-                    "events:PutTargets",
-                    "events:RemoveTargets",
-                    "resource-groups:CreateGroup",
-                    "resource-groups:DeleteGroup",
-                    "resource-groups:Tag",
-                    "resource-groups:Untag",
-                    "resource-groups:UpdateGroupQuery"
-                  ],
-                  "Resource": [
-                    "*"
-                  ]
-                }
-              ]
-            }
 
       - name: Write Terraform variables file
         working-directory: tf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Initialize Terraform
         working-directory: tf
-        run: terraform init
+        run: terraform init -backend-config="bucket=${{ secrets.S3_BUCKET_FOR_STATE }}" -backend-config="key=anime-schedules/terraform.tfstate" -backend-config="region=ap-northeast-1"
 
       - name: Run Terraform Plan
         working-directory: tf
@@ -82,7 +82,7 @@ jobs:
 
       - name: Initialize Terraform
         working-directory: tf
-        run: terraform init
+        run: terraform init -backend-config="bucket=${{ secrets.S3_BUCKET_FOR_STATE }}" -backend-config="key=anime-schedules/terraform.tfstate" -backend-config="region=ap-northeast-1"
 
       - name: Apply Terraform Plan
         working-directory: tf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.5.0
 
@@ -41,7 +41,7 @@ jobs:
         run: terraform plan -var-file=terraform.tfvars -out=tfplan
 
       - name: Upload Terraform Plan as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: terraform-plan
           path: tfplan
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.5.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,15 @@ jobs:
                 {
                   "Effect": "Allow",
                   "Action": [
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "arn:aws:s3:::${{ vars.S3_BUCKET_FOR_STATE }}"
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
                     "s3:GetObject"
                   ],
                   "Resource": [

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -7,6 +7,13 @@ terraform {
   }
 
   required_version = ">= 1.2.0"
+
+  # `terraform init`のときに`-backend-config`で以下の値を設定する
+  # -backend-config="bucket=<BUCKET_NAME>"
+  # -backend-config="key=anime-schedules/terraform.tfstate"
+  # -backend-config="region=ap-northeast-1"
+  backend "s3" {
+  }
 }
 
 provider "aws" {

--- a/tf/modules/main.tf
+++ b/tf/modules/main.tf
@@ -22,6 +22,57 @@ resource "aws_iam_policy_attachment" "main" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+# GitHubとAWSをOIDCで連携するようにIDプロバイダを作成してある。
+# それにGitHubOIDCという名前のロールを割り当てているので、そのロールに
+# このファイルで作成・更新（削除）するリソースを操作するためのポリシーを割り当てる。
+resource "aws_iam_policy" "github_actions_oidc" {
+  name        = "${var.appname}-github-actions-oidc"
+  description = "Policy for GitHub Actions OIDC"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:UpdateRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:PassRole",
+          "iam:CreatePolicy",
+          "iam:DeletePolicy",
+          "iam:UpdatePolicy",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:AddPermission",
+          "lambda:RemovePermission",
+          "logs:CreateLogGroup",
+          "logs:DeleteLogGroup",
+          "logs:PutRetentionPolicy",
+          "events:PutRule",
+          "events:DeleteRule",
+          "events:PutTargets",
+          "events:RemoveTargets",
+          "resource-groups:CreateGroup",
+          "resource-groups:DeleteGroup",
+          "resource-groups:Tag",
+          "resource-groups:Untag",
+          "resource-groups:UpdateGroupQuery"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+resource "aws_iam_policy_attachment" "github_actions_oidc" {
+  name       = "${var.appname}-github-actions-oidc-attachment"
+  policy_arn = aws_iam_policy.github_actions_oidc.arn
+  roles      = ["GitHubOIDC"]
+}
+
 # Lambda
 data "archive_file" "main" {
   type        = "zip"

--- a/tf/modules/main.tf
+++ b/tf/modules/main.tf
@@ -22,57 +22,6 @@ resource "aws_iam_policy_attachment" "main" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
-# GitHubとAWSをOIDCで連携するようにIDプロバイダを作成してある。
-# それにGitHubOIDCという名前のロールを割り当てているので、そのロールに
-# このファイルで作成・更新（削除）するリソースを操作するためのポリシーを割り当てる。
-resource "aws_iam_policy" "github_actions_oidc" {
-  name        = "${var.appname}-github-actions-oidc"
-  description = "Policy for GitHub Actions OIDC"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "iam:CreateRole",
-          "iam:DeleteRole",
-          "iam:UpdateRole",
-          "iam:AttachRolePolicy",
-          "iam:DetachRolePolicy",
-          "iam:PassRole",
-          "iam:CreatePolicy",
-          "iam:DeletePolicy",
-          "iam:UpdatePolicy",
-          "lambda:CreateFunction",
-          "lambda:DeleteFunction",
-          "lambda:UpdateFunctionCode",
-          "lambda:UpdateFunctionConfiguration",
-          "lambda:AddPermission",
-          "lambda:RemovePermission",
-          "logs:CreateLogGroup",
-          "logs:DeleteLogGroup",
-          "logs:PutRetentionPolicy",
-          "events:PutRule",
-          "events:DeleteRule",
-          "events:PutTargets",
-          "events:RemoveTargets",
-          "resource-groups:CreateGroup",
-          "resource-groups:DeleteGroup",
-          "resource-groups:Tag",
-          "resource-groups:Untag",
-          "resource-groups:UpdateGroupQuery"
-        ]
-        Resource = "*"
-      }
-    ]
-  })
-}
-resource "aws_iam_policy_attachment" "github_actions_oidc" {
-  name       = "${var.appname}-github-actions-oidc-attachment"
-  policy_arn = aws_iam_policy.github_actions_oidc.arn
-  roles      = ["GitHubOIDC"]
-}
-
 # Lambda
 data "archive_file" "main" {
   type        = "zip"


### PR DESCRIPTION
- PR作成時にplanを、マージ時にapplyをする
- GitHub Actions と AWS の間の許可はOIDCによって行う。
- terraformの変数ファイルはリポジトリのシークレットに格納する。
    - secretsに改行を含む場合はbase64エンコードしておく必要があるっぽい
        参考 https://zenn.dev/coedo/scraps/d6e1efdf5311c7
- terraform のstateファイルはS3上に持つことにした
    - `terraform init`時に`-backend-config`オプションを付けると設定を注入できる
    - どのS3バケットに置くかはリポジトリの変数で管理

**余談**
IAMにはセッションポリシーという概念がある。
https://docs.aws.amazon.com/ja_jp/IAM/latest/UserGuide/access_policies.html#policies_session
これはアイデンティティポリシーの権限を制限すると考える。`aws-actions/configure-aws-credentials`でオプションに`inline-session-policy`や`managed-session-policy`などがあるが、ここに権限を書いても付与することにはならない。